### PR TITLE
Individual warp penalties

### DIFF
--- a/features/Diana/DianaBurrows.js
+++ b/features/Diana/DianaBurrows.js
@@ -252,8 +252,7 @@ registerWhen(register("packetReceived", (packet) => {
 
 // Delete colored armor stands that no longer exist
 registerWhen(register("step", () => {
-    const enumerator = Object.keys(coloredArmorStands);
-    enumerator.forEach(id => {
+    Object.keys(coloredArmorStands).forEach(id => {
         const armorStand = World.getWorld().func_73045_a(id);
         if (armorStand === null) {
             delete coloredArmorStands[id];
@@ -294,7 +293,7 @@ register("step", () => {
             createBurrowWaypoints(burrows[key][0].type, burrows[key][1].x, burrows[key][1].y +1, burrows[key][1].z, [], burrows[key][2]);
         } 
     }
-}).setFps(4);
+}).setFps(20);
 
 registerWhen(register("packetReceived", (packet) => {
     packettype = packet.func_179749_a().toString()

--- a/features/Diana/DianaGuess.js
+++ b/features/Diana/DianaGuess.js
@@ -335,8 +335,7 @@ function basicallyEqual(a, b) {
 
 function tryToMakeInitialGuess() {
     if (hasMadeManualGuess || hasMadeInitialGuess) return;
-    const enumerator = Object.keys(coloredArmorStands);
-    enumerator.forEach(id => {
+    Object.keys(coloredArmorStands).forEach(id => {
         const armorStand = World.getWorld().func_73045_a(id);
         if (armorStand === null) return;
         const CTArmorStand = new Entity(armorStand);

--- a/features/general/Waypoints.js
+++ b/features/general/Waypoints.js
@@ -217,11 +217,15 @@ function closestWarpString(x, y, z) {
 
 let guessWaypointString = "";
 let hubWarps = {
-    castle: {x: -250, y: 130, z: 45, unlocked: true},
-    da: {x: 92, y: 75, z: 174, unlocked: true},
-    hub: {x: -3, y: 70, z: -70, unlocked: true},
-    museum: {x: -76, y: 76, z: 81, unlocked: true},
+    castle: {x: -250, y: 130, z: 45, unlocked: true, penalty: settings.castleWarpPenalty},
+    da: {x: 92, y: 75, z: 174, unlocked: true, penalty: settings.darkAuctionWarpPenalty},
+    hub: {x: -3, y: 70, z: -70, unlocked: true, penalty: settings.hubWarpPenalty},
+    museum: {x: -76, y: 76, z: 81, unlocked: true, penalty: settings.museumWarpPenalty},
 };
+settings.registerListener("Castle Warp Penalty", (value) => hubWarps.castle.penalty = value);
+settings.registerListener("Dark Auction Warp Penalty", (value) => hubWarps.da.penalty = value);
+settings.registerListener("Hub Warp Penalty", (value) => hubWarps.hub.penalty = value);
+settings.registerListener("Museum Warp Penalty", (value) => hubWarps.museum.penalty = value);
 
 const warpKey = new Keybind("Burrow Warp", Keyboard.KEY_NONE, "SkyblockOverhaul");
 let tryWarp = false;
@@ -272,21 +276,21 @@ function getClosestWarp(x, y, z) {
             delete hubWarps.crypt;
             break;
         case 1:
-            hubWarps.wizard = {x: 42, y: 122, z: 69, unlocked: true}
+            hubWarps.wizard = {x: 42, y: 122, z: 69, unlocked: true, penalty: settings.wizardWarpPenalty}
             delete hubWarps.crypt;
             break;
         case 2:
-            hubWarps.crypt = {x: -161, y: 61, z: -99, unlocked: true}
+            hubWarps.crypt = {x: -161, y: 61, z: -99, unlocked: true, penalty: settings.cryptWarpPenalty}
             delete hubWarps.wizard;
             break;
         case 3:
-            hubWarps.wizard = {x: 42, y: 122, z: 69, unlocked: true}
-            hubWarps.crypt = {x: -161, y: 61, z: -99, unlocked: true}
+            hubWarps.wizard = {x: 42, y: 122, z: 69, unlocked: true, penalty: settings.wizardWarpPenalty}
+            hubWarps.crypt = {x: -161, y: 61, z: -99, unlocked: true, penalty: settings.cryptWarpPenalty}
             break;
     }
 
     if (settings.stonksWarp) {
-        hubWarps.stonks = {x: -53, y: 72, z: -53, unlocked: true}
+        hubWarps.stonks = {x: -53, y: 72, z: -53, unlocked: true, penalty: settings.stonksWarpPenalty}
     } else {
         delete hubWarps.stonks;
     }
@@ -306,6 +310,7 @@ function getClosestWarp(x, y, z) {
     }
     settings.warpDiff = settings.warpDiff.replace(/\D/g, '');
     let warpDiff = parseInt(settings.warpDiff);
+    if (settings.individualWarpPenalties) warpDiff += hubWarps[closestWarp].penalty;
 
     const warpConditions = {
         condition1: Math.round(parseInt(closestPlayerdistance)) > Math.round(parseInt(closestDistance) + warpDiff),

--- a/settings.js
+++ b/settings.js
@@ -4,6 +4,7 @@ import {
     @CheckboxProperty,
     Color,
     @ColorProperty,
+    @NumberProperty,
     @PercentSliderProperty,
     @SelectorProperty,
     @SwitchProperty,
@@ -83,8 +84,14 @@ class Settings {
         this.addDependency('Golden Fish Notification','Golden Fish Timer');
         this.addDependency('Flare Expire Soon Alert','Flare Tracker');
         this.addDependency('Hide Own Flare When Not In Range','Flare Tracker');
-        this.addDependency('Burrow Guess Alternative','Diana Burrow Guess');
-
+        this.addDependency('Initial Burrow Guess','Diana Burrow Guess');
+        this.addDependency('Hub Warp Penalty', 'Use Individual Warp Penalties');
+        this.addDependency('Crypt Warp Penalty', 'Use Individual Warp Penalties');
+        this.addDependency('Wizard Warp Penalty', 'Use Individual Warp Penalties');
+        this.addDependency('Stonks Warp Penalty', 'Use Individual Warp Penalties');
+        this.addDependency('Castle Warp Penalty', 'Use Individual Warp Penalties');
+        this.addDependency('Dark Auction Warp Penalty', 'Use Individual Warp Penalties');
+        this.addDependency('Museum Warp Penalty', 'Use Individual Warp Penalties');
     } 
     //-----------Diana Burrows----------------
     @SwitchProperty({
@@ -95,8 +102,8 @@ class Settings {
     })
     dianaBurrowGuess = true;
     @SwitchProperty({
-        name: "Burrow Guess Alternative",
-        description: "[WIP] Makes a guess based on the arrow that spawns when you finished a burrow and the color it shows",
+        name: "Initial Burrow Guess",
+        description: "[WIP] Makes an initial guess based on the color of the arrow that spawns when you finished a burrow. Useful for when you want to warp before making an accurate guess",
         category: "Diana",
         subcategory: "Diana Burrows"
     })
@@ -129,6 +136,63 @@ class Settings {
         subcategory: "Diana Burrows"
     })
     warpDiff = "10";
+    @SwitchProperty({
+        name: "Use Individual Warp Penalties",
+        description: "Enables you to set an individual distance penalty for each warp, if you want to favor certain warps over others",
+        category: "Diana",
+        subcategory: "Warps",
+        min: 0, max: 50, increment: 10
+    })
+    individualWarpPenalties = false;
+    @NumberProperty({
+        name: "Hub Warp Penalty",
+        category: "Diana",
+        subcategory: "Warps",
+        min: 0, max: 50, increment: 10
+    })
+    hubWarpPenalty = 0;
+    @NumberProperty({
+        name: "Crypt Warp Penalty",
+        category: "Diana",
+        subcategory: "Warps",
+        min: 0, max: 50, increment: 10
+    })
+    cryptWarpPenalty = 0;
+    @NumberProperty({
+        name: "Wizard Warp Penalty",
+        category: "Diana",
+        subcategory: "Warps",
+        min: 0, max: 50, increment: 10
+    })
+    wizardWarpPenalty = 0;
+    @NumberProperty({
+        name: "Stonks Warp Penalty",
+        category: "Diana",
+        subcategory: "Warps",
+        min: 0, max: 50, increment: 10
+    })
+    stonksWarpPenalty = 0;
+    @NumberProperty({
+        name: "Castle Warp Penalty",
+        category: "Diana",
+        subcategory: "Warps",
+        min: 0, max: 50, increment: 10
+    })
+    castleWarpPenalty = 0;
+    @NumberProperty({
+        name: "Dark Auction Warp Penalty",
+        category: "Diana",
+        subcategory: "Warps",
+        min: 0, max: 50, increment: 10
+    })
+    darkAuctionWarpPenalty = 0;
+    @NumberProperty({
+        name: "Museum Warp Penalty",
+        category: "Diana",
+        subcategory: "Warps",
+        min: 0, max: 50, increment: 10
+    })
+    museumWarpPenalty = 0;
 
     // --- Diana Tracker ---
     @SwitchProperty({

--- a/settings.js
+++ b/settings.js
@@ -136,63 +136,6 @@ class Settings {
         subcategory: "Diana Burrows"
     })
     warpDiff = "10";
-    @SwitchProperty({
-        name: "Use Individual Warp Penalties",
-        description: "Enables you to set an individual distance penalty for each warp, if you want to favor certain warps over others",
-        category: "Diana",
-        subcategory: "Warps",
-        min: 0, max: 50, increment: 10
-    })
-    individualWarpPenalties = false;
-    @NumberProperty({
-        name: "Hub Warp Penalty",
-        category: "Diana",
-        subcategory: "Warps",
-        min: 0, max: 50, increment: 10
-    })
-    hubWarpPenalty = 0;
-    @NumberProperty({
-        name: "Crypt Warp Penalty",
-        category: "Diana",
-        subcategory: "Warps",
-        min: 0, max: 50, increment: 10
-    })
-    cryptWarpPenalty = 0;
-    @NumberProperty({
-        name: "Wizard Warp Penalty",
-        category: "Diana",
-        subcategory: "Warps",
-        min: 0, max: 50, increment: 10
-    })
-    wizardWarpPenalty = 0;
-    @NumberProperty({
-        name: "Stonks Warp Penalty",
-        category: "Diana",
-        subcategory: "Warps",
-        min: 0, max: 50, increment: 10
-    })
-    stonksWarpPenalty = 0;
-    @NumberProperty({
-        name: "Castle Warp Penalty",
-        category: "Diana",
-        subcategory: "Warps",
-        min: 0, max: 50, increment: 10
-    })
-    castleWarpPenalty = 0;
-    @NumberProperty({
-        name: "Dark Auction Warp Penalty",
-        category: "Diana",
-        subcategory: "Warps",
-        min: 0, max: 50, increment: 10
-    })
-    darkAuctionWarpPenalty = 0;
-    @NumberProperty({
-        name: "Museum Warp Penalty",
-        category: "Diana",
-        subcategory: "Warps",
-        min: 0, max: 50, increment: 10
-    })
-    museumWarpPenalty = 0;
 
     // --- Diana Tracker ---
     @SwitchProperty({
@@ -1020,6 +963,65 @@ class Settings {
         max: 100
     })
     achievementVolume = 50;
+
+    // Individual Warp Penalties
+    @SwitchProperty({
+        name: "Use Individual Warp Penalties",
+        description: "Enables you to set an individual distance penalty for each warp, if you want to favor certain warps over others",
+        category: "Customization",
+        subcategory: "Warp Penalties",
+        min: 0, max: 50, increment: 10
+    })
+    individualWarpPenalties = false;
+    @NumberProperty({
+        name: "Hub Warp Penalty",
+        category: "Customization",
+        subcategory: "Warp Penalties",
+        min: 0, max: 50, increment: 10
+    })
+    hubWarpPenalty = 0;
+    @NumberProperty({
+        name: "Crypt Warp Penalty",
+        category: "Customization",
+        subcategory: "Warp Penalties",
+        min: 0, max: 50, increment: 10
+    })
+    cryptWarpPenalty = 0;
+    @NumberProperty({
+        name: "Wizard Warp Penalty",
+        category: "Customization",
+        subcategory: "Warp Penalties",
+        min: 0, max: 50, increment: 10
+    })
+    wizardWarpPenalty = 0;
+    @NumberProperty({
+        name: "Stonks Warp Penalty",
+        category: "Customization",
+        subcategory: "Warp Penalties",
+        min: 0, max: 50, increment: 10
+    })
+    stonksWarpPenalty = 0;
+    @NumberProperty({
+        name: "Castle Warp Penalty",
+        category: "Customization",
+        subcategory: "Warp Penalties",
+        min: 0, max: 50, increment: 10
+    })
+    castleWarpPenalty = 0;
+    @NumberProperty({
+        name: "Dark Auction Warp Penalty",
+        category: "Customization",
+        subcategory: "Warp Penalties",
+        min: 0, max: 50, increment: 10
+    })
+    darkAuctionWarpPenalty = 0;
+    @NumberProperty({
+        name: "Museum Warp Penalty",
+        category: "Customization",
+        subcategory: "Warp Penalties",
+        min: 0, max: 50, increment: 10
+    })
+    museumWarpPenalty = 0;
 
     // Partyfinder
     @SwitchProperty({


### PR DESCRIPTION
Added the ability to set distance penalties for each individual warp, since some warps are much more open-spaced than others. The penalty just adds on top of the already set warpDiff. Also changed name and description of the initial guess slightly, and reduced the slight bit of downtime from waiting until a burrow is loaded by updating more frequently (shouldn't impact performance negatively since it's just a normal function being called).